### PR TITLE
feat: improve search page outline context

### DIFF
--- a/docs/specs/01-functional-spec.md
+++ b/docs/specs/01-functional-spec.md
@@ -163,7 +163,7 @@ Top-level output fields:
 1. Validate URL against SSRF allowlist; validate `offset` >= 1, `limit` >= 1, `before` >= 0. Apply minimal URL normalization first: trim outer whitespace, lowercase scheme and host, and remove default ports (`:80` for `http`, `:443` for `https`). Preserve path, query string, fragment, and trailing slash exactly.
 2. Check SQLite cache for `url_hash = sha256(normalized_url)` — if fresh, return from cache
 3. On cache miss: if URL does not already end with `.md`, try fetching `url + ".md"` first only when both conditions hold: (a) the URL shape still passes the existing probe heuristic (no query string, no trailing slash, no alphabetic file extension), and (b) the URL's normalized origin exactly matches one of the `useful_md_probe_base_urls` loaded from the optional registry additional-info sidecar. On any probe failure (404, timeout, network error), fall back to the normalized URL silently. A 200 HTML response from the `.md` probe is accepted as-is — no fallback, since the original URL would return the same content on an SPA. If the additional-info sidecar is missing or invalid, `.md` probing is disabled. `.md` is never appended to redirect targets; redirects are followed as the server directs. Store full content + outline in SQLite cache keyed against the normalized URL.
-4. If `include_outline=true`, compact outline for response (progressive depth reduction to satisfy both ≤max_entries and ≤max_chars; status message if irreducible). Otherwise set `outline=null`.
+4. If `include_outline=true`, compact outline for response (progressive depth reduction to satisfy both ≤max_entries and the `read_page` outline character limit; status message if irreducible). Otherwise set `outline=null`.
 5. Slice content to the requested window: start at `max(1, offset - before)` and end at `min(total_lines, offset + limit - 1)`
 6. Return compacted outline, windowed content, and pagination metadata
 
@@ -193,7 +193,7 @@ Top-level output fields:
 | Field          | Description                                                                                                                                             |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`          | The normalized URL used for fetch and cache identity. Path, query string, fragment, and trailing slash are preserved exactly, so `/page` and `/page/` remain distinct. |
-| `outline`      | Compacted structural outline of the page (target: ≤max_entries entries AND ≤max_chars characters). Progressive depth reduction removes lower-priority headings (H6 → H5 → fenced content → H4 → H3) until both constraints are satisfied. When the page outline cannot be reduced below both limits even after maximum reduction, this field contains a status message directing the agent to use `read_outline` for paginated access. Each entry: `<line_number>:<emitted outline text>`. ATX headings and fence markers preserve the source line; supported setext headings are normalized to synthetic `#` / `##` entries. `null` when `include_outline=false`. |
+| `outline`      | Compacted structural outline of the page (target: ≤max_entries entries AND the configured `read_page` outline character limit). Progressive depth reduction removes lower-priority headings (H6 → H5 → fenced content → H4 → H3) until both constraints are satisfied. When the page outline cannot be reduced below both limits even after maximum reduction, this field contains a status message directing the agent to use `read_outline` for paginated access. Each entry: `<line_number>:<emitted outline text>`. ATX headings and fence markers preserve the source line; supported setext headings are normalized to synthetic `#` / `##` entries. `null` when `include_outline=false`. |
 | `total_lines`  | Total number of lines in the full page. Useful for determining if more content exists beyond the current window.                                        |
 | `offset`       | The 1-based line number the returned content actually starts from after applying `before` and clamping to line 1.                                     |
 | `limit`        | The maximum number of forward lines requested from the input `offset`.                                                                                  |
@@ -207,7 +207,7 @@ Top-level output fields:
 
 **Notes**:
 
-- The outline is compacted to satisfy both max_entries (default ≤50) and max_chars (default ≤4000) constraints to save tokens and ensure readability. For the complete outline, use `read_outline`. These limits are configurable via settings.
+- The outline is compacted to satisfy both max_entries (default ≤50) and the `read_page` character budget (default ≤4000) to save tokens and ensure readability. For the complete outline, use `read_outline`. These limits are configurable via settings.
 - The full page and outline are cached together on first fetch. Subsequent calls with different offsets are served from cache — no re-fetch or re-parse.
 - `search_page` and `read_outline` share the same cache — a page fetched by any tool is available to the others without a re-fetch.
 - URL normalization is intentionally minimal. Equivalent host-case and default-port variants share cache entries, but trailing slash differences do not.
@@ -241,9 +241,9 @@ This tool is the equivalent of `grep` for documentation pages. It supports liter
 3. Starting from `offset`, search either page content lines (`target="content"`) or stored outline entries (`target="outline"`) for a match against `query` (respecting `mode`, `case_mode`, `whole_word`)
 4. Collect up to `max_results` matching lines
 5. In `target="outline"` mode, ignore the `<line_number>:` prefix when matching, but preserve the original outline line format in results
-6. In `target="content"` mode, if there are no matches, return an empty outline string
-7. In `target="content"` mode, if the full outline already satisfies both ≤max_entries and ≤max_chars after empty-fence stripping, return it unchanged
-8. In `target="content"` mode, otherwise trim the outline to the range between first and last match line numbers, then compact it (progressive depth reduction to satisfy both constraints; status message if irreducible)
+6. In `target="content"` mode, if there are no matches, skip range trimming and compact the full outline using the normal search-page limits
+7. In `target="content"` mode, if the full outline already satisfies both ≤max_entries and the configured `search_page` outline character limit after empty-fence stripping, return it unchanged
+8. In `target="content"` mode, otherwise trim the outline to the range between first and last match line numbers, prepend the active ancestor heading chain for the first match (prefer H2 as the root, fall back to H1, otherwise use the available local chain), then apply progressive reduction until both constraints are satisfied
 9. In `target="outline"` mode, always return `outline=null`
 10. Return matching lines and pagination metadata
 
@@ -268,7 +268,7 @@ This tool is the equivalent of `grep` for documentation pages. It supports liter
 
 | Field          | Description                                                                                                               |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| `outline`      | Structural outline context for content-mode search results. `null` in `target="outline"` mode because outline context is not applicable there. In content mode, may be an empty string when the page has no outline entries. |
+| `outline`      | Structural outline context for content-mode search results. `null` in `target="outline"` mode because outline context is not applicable there. In content mode, may be an empty string when the page has no outline entries. On oversized pages with matches, this context includes the rolled-up ancestor chain immediately preceding the first match. |
 | `matches`      | Matching lines formatted as `<line_number>:<content>`, one per line. In `target="outline"` mode, these are matching outline entries in the same format. Empty string when no matches found. |
 | `total_lines`  | Total number of lines in the page.                                                                                        |
 | `has_more`     | `true` if more matches exist beyond the returned set.                                                                     |
@@ -281,7 +281,7 @@ This tool is the equivalent of `grep` for documentation pages. It supports liter
 
 - Matches are returned in document order (ascending line number).
 - The agent cross-references match line numbers against the outline to determine which section each match belongs to, then uses `read_page` with the appropriate `offset` to read the full section.
-- Small outlines are returned in full because trimming them can remove useful parent headings. Only oversized outlines are range-trimmed.
+- Small outlines are returned in full because trimming them can remove useful parent headings. Only oversized outlines are range-trimmed. When range trimming occurs, `search_page` prepends the active heading chain immediately preceding the first match so the outline does not start abruptly. `search_page` uses a smaller default outline character budget than `read_page` because content-mode search has no `include_outline=false` escape hatch.
 - In `regex` mode, invalid patterns are rejected with `INVALID_INPUT`. Patterns are length-capped to prevent ReDoS.
 - `search_page` shares the same cache and fetch path as `read_page` and `read_outline`. A page fetched by any tool is immediately available to the others.
 

--- a/docs/specs/02-technical-spec.md
+++ b/docs/specs/02-technical-spec.md
@@ -113,7 +113,7 @@ read_page("https://python.langchain.com/llms.txt")
   ├─ Fetch: HTTP GET url (30s timeout, initial URL allowlisted; private IPs blocked on redirect hops)
   ├─ Store: page_cache (TTL 24h)
   ├─ Parse: extract outline (H1–H6, fence lines, line numbers)
-  ├─ Compact outline (progressive depth reduction → ≤max_entries AND ≤max_chars, or status message)
+  ├─ Compact outline (progressive depth reduction → ≤max_entries AND the read_page char budget, or status message)
   └─ Return: { outline: "...", content: "...", has_more: bool }
 
 search_page("https://python.langchain.com/llms.txt", "streaming")
@@ -124,9 +124,10 @@ search_page("https://python.langchain.com/llms.txt", "streaming")
   │    MISS → fetch and cache (same path as read_page)
   ├─ Build matcher from query + mode + case_mode + whole_word
   ├─ Scan lines from offset, collect up to max_results matches
-  ├─ If outline is already small (≤max_entries AND ≤max_chars after empty-fence stripping), return it unchanged
+  ├─ If outline is already small (≤max_entries AND the search_page char budget after empty-fence stripping), return it unchanged
   ├─ Otherwise trim outline to match range (first match line → last match line)
-  ├─ Compact the oversized trimmed outline (progressive depth reduction → ≤max_entries AND ≤max_chars)
+  ├─ Prepend the active ancestor chain for the first match (prefer H2, fall back to H1)
+  ├─ Compact the oversized rolled-up outline (progressive depth reduction → ≤max_entries AND the search_page char budget)
   └─ Return: { outline: "...", matches: [...], has_more: bool }
 
 read_outline("https://python.langchain.com/llms.txt", offset=1, limit=1000)
@@ -999,15 +1000,29 @@ After each stage, the formatted outline is checked against both constraints via 
 
 If the entry count still exceeds `max_entries` OR the formatted string exceeds `max_chars` after all reductions (only H1/H2 remain), returns `None`. The caller renders a status message: `"[Outline too large (N entries). Use read_outline for paginated access.]"`
 
-These limits are configurable via `settings.outline.max_entries` and `settings.outline.max_chars` (defaults: 50 entries, 4000 characters).
+These limits are configurable via `settings.outline.max_entries`, `settings.outline.read_page_max_chars`, and `settings.outline.search_page_max_chars` (defaults: 50 entries, 4000 characters for `read_page`, 1000 characters for `search_page`).
 
 ### 7.5 Match-Range Trimming
 
 `trim_outline_to_range(entries: list[OutlineEntry], first_line: int, last_line: int) -> list[OutlineEntry]`
 
-Used by `search_page` before compaction. Filters entries to those with `line_number` between `first_line` and `last_line` (inclusive). When zero matches are found, the caller skips trimming and compaction entirely and returns an empty outline string.
+Used by `search_page` before rollup and compaction. Filters entries to those with `line_number` between `first_line` and `last_line` (inclusive). When zero matches are found, the caller skips range trimming and falls back to normal full-outline compaction.
 
-### 7.6 Formatting
+### 7.6 Search Outline Rollup
+
+`build_ancestor_rollup(entries: list[OutlineEntry], first_match_line: int) -> list[OutlineEntry]`
+
+Used only by oversized `search_page` content-mode responses. Walks headings strictly before `first_match_line` using a depth-aware stack that keeps only the active ancestor path at the match boundary.
+
+Root selection policy:
+
+1. Prefer the nearest surviving `H2`
+2. If no `H2` survives, fall back to the nearest surviving `H1`
+3. If neither exists, return the available local chain
+
+The rollup is computed separately for each progressive reduction stage so headings removed by H6/H5/fence/H4/H3 filtering are never reintroduced.
+
+### 7.7 Formatting
 
 `format_outline(entries: list[OutlineEntry]) -> str`
 
@@ -1551,7 +1566,8 @@ resolver:
 
 outline:
   max_entries: 50 # maximum entry count in compacted outlines (read_page, search_page)
-  max_chars: 4000 # maximum character count in compacted outlines (as formatted string)
+  read_page_max_chars: 4000 # max formatted outline chars returned by read_page
+  search_page_max_chars: 1000 # tighter max formatted outline chars returned by search_page
 
 logging:
   level: INFO # DEBUG | INFO | WARNING | ERROR
@@ -1600,7 +1616,8 @@ class ResolverSettings(BaseModel):
 
 class OutlineSettings(BaseModel):
     max_entries: int = 50 # maximum entry count in compacted outlines
-    max_chars: int = 4000 # maximum character count in compacted outlines
+    read_page_max_chars: int = 4000 # maximum character count in read_page outlines
+    search_page_max_chars: int = 1000 # maximum character count in search_page outlines
 
 class LoggingSettings(BaseModel):
     level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"

--- a/docs/specs/04-api-reference.md
+++ b/docs/specs/04-api-reference.md
@@ -591,7 +591,7 @@ For pages where the outline is replaced by a status message (very large pages), 
     },
     "outline": {
       "type": ["string", "null"],
-      "description": "Compacted structural outline of the page (target ≤50 entries). Progressive depth reduction removes lower-priority headings. When the page outline is too large even after maximum compaction, contains a status message directing to read_outline. Each entry formatted as '<line_number>:<emitted outline text>'; ATX headings and fence markers preserve the source line, while supported setext headings are normalized to synthetic '#'/ '##' entries. Null when include_outline=false."
+      "description": "Compacted structural outline of the page (target ≤50 entries and the configured read_page outline character budget). Progressive depth reduction removes lower-priority headings. When the page outline is too large even after maximum compaction, contains a status message directing to read_outline. Each entry formatted as '<line_number>:<emitted outline text>'; ATX headings and fence markers preserve the source line, while supported setext headings are normalized to synthetic '#'/ '##' entries. Null when include_outline=false."
     },
     "total_lines": {
       "type": "integer",
@@ -629,7 +629,7 @@ For pages where the outline is replaced by a status message (very large pages), 
 }
 ```
 
-**Outline compaction**: The outline is compacted to ≤50 entries by progressively removing lower-priority headings (H6 → H5 → fenced content → H4 → H3). If even H1/H2 exceed 50 entries, the field contains a status message. The full outline and content are cached together so subsequent calls with different offsets don't re-fetch.
+**Outline compaction**: The outline is compacted to ≤50 entries and the configured `read_page` outline character budget by progressively removing lower-priority headings (H6 → H5 → fenced content → H4 → H3). If even H1/H2 exceed either limit, the field contains a status message. The full outline and content are cached together so subsequent calls with different offsets don't re-fetch.
 
 **Cache sharing**: `read_page`, `search_page`, and `read_outline` share the same `page_cache`. A page fetched by any tool is immediately available to the others without a re-fetch.
 
@@ -829,7 +829,7 @@ This tool is the equivalent of `grep` for documentation pages. It supports liter
     },
     "outline": {
       "type": ["string", "null"],
-      "description": "Structural outline context for content-mode search results. Null when target='outline' because outline context is not applicable in that mode."
+      "description": "Structural outline context for content-mode search results. Null when target='outline' because outline context is not applicable in that mode. On oversized pages with matches, the returned outline prepends the active ancestor heading chain immediately preceding the first match. Content-mode search uses a tighter default outline character budget than read_page."
     },
     "matches": {
       "type": "string",

--- a/procontext.example.yaml
+++ b/procontext.example.yaml
@@ -106,15 +106,18 @@ resolver:
 outline:
   # Maximum number of entries in compacted outlines returned by read_page and
   # search_page. Outlines are progressively reduced (H6 → H5 → fenced → H4 → H3)
-  # until entry count ≤ max_entries AND char count ≤ max_chars. Both constraints
-  # are active simultaneously. If the outline cannot be reduced below both limits,
-  # a status message directs the agent to use read_outline for paginated browsing.
+  # until entry count ≤ max_entries AND the tool-specific char limit is met.
+  # If the outline cannot be reduced below both limits, a status message directs
+  # the agent to use read_outline for paginated browsing.
   max_entries: 50
 
-  # Maximum character count (as formatted outline string) in compacted outlines.
-  # Prevents token bloat when headings are long. Works with max_entries to ensure
-  # outlines are both structurally concise and token-efficient. See max_entries above.
-  max_chars: 4000
+  # Maximum character count (as formatted outline string) for read_page outlines.
+  # This can stay larger because callers can set include_outline=false on later reads.
+  read_page_max_chars: 4000
+
+  # Maximum character count (as formatted outline string) for search_page outlines.
+  # Kept tighter because search_page always includes outline context in content mode.
+  search_page_max_chars: 1000
 
 logging:
   level: INFO # DEBUG | INFO | WARNING | ERROR

--- a/src/procontext/config.py
+++ b/src/procontext/config.py
@@ -14,7 +14,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import platformdirs
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -80,7 +80,21 @@ class ResolverSettings(BaseModel):
 class OutlineSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
     max_entries: int = Field(default=50, gt=0)
-    max_chars: int = Field(default=4000, gt=0)
+    read_page_max_chars: int = Field(default=4000, gt=0)
+    search_page_max_chars: int = Field(default=1000, gt=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def apply_legacy_max_chars_alias(cls, data: Any) -> Any:
+        """Map legacy ``max_chars`` to both per-tool limits for compatibility."""
+        if not isinstance(data, dict) or "max_chars" not in data:
+            return data
+
+        normalized = dict(data)
+        legacy_value = normalized.pop("max_chars")
+        normalized.setdefault("read_page_max_chars", legacy_value)
+        normalized.setdefault("search_page_max_chars", legacy_value)
+        return normalized
 
 
 class LoggingSettings(BaseModel):

--- a/src/procontext/outline.py
+++ b/src/procontext/outline.py
@@ -1,4 +1,4 @@
-"""Outline structuring, compaction, match-range trimming, and formatting.
+"""Outline structuring, compaction, reduction stages, and formatting.
 
 Parses the raw outline string (cached alongside page content) into structured
 entries, applies intelligent compaction for token-efficient responses, and
@@ -11,12 +11,15 @@ This module operates on that cached string at response time.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 import structlog
 
 from procontext.parser import _FENCE_RE, _is_matching_fence_closer, _match_heading
 
 log = structlog.get_logger()
+
+OutlineReductionStage = Literal["none", "drop_h6", "drop_h5", "drop_fenced", "drop_h4", "drop_h3"]
 
 
 @dataclass(frozen=True)
@@ -161,6 +164,39 @@ def strip_empty_fences(entries: list[OutlineEntry]) -> list[OutlineEntry]:
 # ---------------------------------------------------------------------------
 
 
+def apply_outline_reduction_stage(
+    entries: list[OutlineEntry], stage: OutlineReductionStage
+) -> list[OutlineEntry]:
+    """Apply a single progressive reduction stage to outline entries."""
+    if stage == "none":
+        return entries
+    if stage == "drop_h6":
+        return [entry for entry in entries if entry.depth != 6]
+    if stage == "drop_h5":
+        return [entry for entry in entries if entry.depth != 5]
+    if stage == "drop_fenced":
+        return [entry for entry in entries if not entry.in_fence and not entry.is_fence]
+    if stage == "drop_h4":
+        return [entry for entry in entries if entry.depth != 4]
+    return [entry for entry in entries if entry.depth != 3]
+
+
+def iter_outline_reduction_stages(
+    entries: list[OutlineEntry],
+) -> list[tuple[OutlineReductionStage, list[OutlineEntry]]]:
+    """Return entries after each progressive reduction stage.
+
+    The stages are cumulative and ordered exactly as read_page/search_page
+    compaction applies them.
+    """
+    stages: list[tuple[OutlineReductionStage, list[OutlineEntry]]] = [("none", entries)]
+    result = entries
+    for stage in ("drop_h6", "drop_h5", "drop_fenced", "drop_h4", "drop_h3"):
+        result = apply_outline_reduction_stage(result, stage)
+        stages.append((stage, result))
+    return stages
+
+
 def compact_outline(
     entries: list[OutlineEntry],
     *,
@@ -182,35 +218,9 @@ def compact_outline(
     Returns ``None`` if the outline cannot be reduced to satisfy both constraints
     (only H1/H2 remain and still exceed either limit).
     """
-    if len(entries) <= max_entries and _formatted_outline_size(entries) <= max_chars:
-        return entries
-
-    result = entries
-
-    # Stage 1: Remove H6
-    result = [e for e in result if e.depth != 6]
-    if len(result) <= max_entries and _formatted_outline_size(result) <= max_chars:
-        return result
-
-    # Stage 2: Remove H5
-    result = [e for e in result if e.depth != 5]
-    if len(result) <= max_entries and _formatted_outline_size(result) <= max_chars:
-        return result
-
-    # Stage 3: Remove fenced content and fence markers
-    result = [e for e in result if not e.in_fence and not e.is_fence]
-    if len(result) <= max_entries and _formatted_outline_size(result) <= max_chars:
-        return result
-
-    # Stage 4: Remove H4
-    result = [e for e in result if e.depth != 4]
-    if len(result) <= max_entries and _formatted_outline_size(result) <= max_chars:
-        return result
-
-    # Stage 5: Remove H3
-    result = [e for e in result if e.depth != 3]
-    if len(result) <= max_entries and _formatted_outline_size(result) <= max_chars:
-        return result
+    for _stage, result in iter_outline_reduction_stages(entries):
+        if len(result) <= max_entries and _formatted_outline_size(result) <= max_chars:
+            return result
 
     # Irreducible — only H1/H2 remain and still exceed at least one constraint
     return None

--- a/src/procontext/search_outline_context.py
+++ b/src/procontext/search_outline_context.py
@@ -1,0 +1,128 @@
+"""Pure helpers for building search_page outline context.
+
+This module handles range trimming, ancestor rollup, and stage-aware reduction
+for oversized search_page outline responses.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from procontext.outline import (
+    OutlineEntry,
+    compact_outline,
+    format_outline,
+    iter_outline_reduction_stages,
+    trim_outline_to_range,
+)
+
+
+@dataclass(frozen=True)
+class SearchOutlineSelection:
+    """Selected outline entries for search_page plus compaction metadata."""
+
+    entries: list[OutlineEntry]
+    compacted: bool
+
+
+def select_search_outline_entries(
+    entries: list[OutlineEntry],
+    first_line: int | None,
+    last_line: int | None,
+    *,
+    max_entries: int,
+    max_chars: int,
+) -> SearchOutlineSelection | None:
+    """Build the search_page outline for the current match span.
+
+    Small full outlines are returned unchanged. For no-match cases, this falls
+    back to normal compaction. For oversized match ranges, ancestor rollup is
+    computed separately for each reduction stage so filtered headings are never
+    reintroduced.
+    """
+    if len(entries) <= max_entries and len(format_outline(entries)) <= max_chars:
+        return SearchOutlineSelection(entries=entries, compacted=False)
+
+    if first_line is None or last_line is None:
+        compacted = compact_outline(entries, max_entries=max_entries, max_chars=max_chars)
+        if compacted is None:
+            return None
+        return SearchOutlineSelection(entries=compacted, compacted=True)
+
+    for stage, stage_entries in iter_outline_reduction_stages(entries):
+        candidate = build_match_range_with_rollup(stage_entries, first_line, last_line)
+        if len(candidate) <= max_entries and len(format_outline(candidate)) <= max_chars:
+            return SearchOutlineSelection(entries=candidate, compacted=stage != "none")
+
+    return None
+
+
+def build_match_range_with_rollup(
+    entries: list[OutlineEntry],
+    first_line: int,
+    last_line: int,
+    *,
+    root_floor_depth: int = 2,
+) -> list[OutlineEntry]:
+    """Return trimmed match-range entries preceded by rolled-up ancestor context."""
+    trimmed = trim_outline_to_range(entries, first_line, last_line)
+    ancestors = build_ancestor_rollup(
+        entries,
+        first_line,
+        root_floor_depth=root_floor_depth,
+    )
+    return merge_outline_entries(ancestors, trimmed)
+
+
+def build_ancestor_rollup(
+    entries: list[OutlineEntry],
+    first_match_line: int,
+    *,
+    root_floor_depth: int = 2,
+) -> list[OutlineEntry]:
+    """Build the active heading chain immediately before *first_match_line*.
+
+    Uses the current surviving entries only. The returned chain starts at the
+    nearest surviving H2 when present, otherwise the nearest surviving H1, and
+    otherwise the full available local chain.
+    """
+    stack: list[OutlineEntry] = []
+
+    for entry in entries:
+        if entry.line_number >= first_match_line:
+            break
+        if entry.depth is None:
+            continue
+
+        while stack and stack[-1].depth is not None and stack[-1].depth >= entry.depth:
+            stack.pop()
+        stack.append(entry)
+
+    if not stack:
+        return []
+
+    root_index = _rollup_root_index(stack, root_floor_depth=root_floor_depth)
+    return stack[root_index:]
+
+
+def merge_outline_entries(
+    ancestors: list[OutlineEntry],
+    trimmed: list[OutlineEntry],
+) -> list[OutlineEntry]:
+    """Merge two outline entry lists in document order, deduplicated by line number."""
+    merged: dict[int, OutlineEntry] = {}
+    for entry in ancestors + trimmed:
+        merged.setdefault(entry.line_number, entry)
+    return sorted(merged.values(), key=lambda entry: entry.line_number)
+
+
+def _rollup_root_index(stack: list[OutlineEntry], *, root_floor_depth: int) -> int:
+    h2_index = next((i for i, entry in enumerate(stack) if entry.depth == root_floor_depth), None)
+    if h2_index is not None:
+        return h2_index
+
+    h1_index = next((i for i, entry in enumerate(stack) if entry.depth == 1), None)
+    if h1_index is not None:
+        return h1_index
+
+    return 0

--- a/src/procontext/tools/read_page.py
+++ b/src/procontext/tools/read_page.py
@@ -67,7 +67,7 @@ async def handle(
         _compact_page_outline(
             result.outline,
             max_entries=state.settings.outline.max_entries,
-            max_chars=state.settings.outline.max_chars,
+            max_chars=state.settings.outline.read_page_max_chars,
         )
         if validated.include_outline
         else None

--- a/src/procontext/tools/search_page.py
+++ b/src/procontext/tools/search_page.py
@@ -15,14 +15,13 @@ from procontext.errors import ErrorCode, ProContextError
 from procontext.models.tools import SearchPageInput, SearchPageOutput
 from procontext.outline import (
     build_compaction_note,
-    compact_outline,
     format_outline,
     parse_outline_entries,
     strip_empty_fences,
-    trim_outline_to_range,
 )
 from procontext.page import fetch_or_cached_page
 from procontext.search import LineMatch, SearchResult, build_matcher, search_lines
+from procontext.search_outline_context import select_search_outline_entries
 
 if TYPE_CHECKING:
     from procontext.state import AppState
@@ -118,7 +117,7 @@ async def handle(
             first_line,
             last_line,
             max_entries=state.settings.outline.max_entries,
-            max_chars=state.settings.outline.max_chars,
+            max_chars=state.settings.outline.search_page_max_chars,
         )
 
     output = SearchPageOutput(
@@ -194,38 +193,30 @@ def _compact_search_outline(
     max_entries: int = 50,
     max_chars: int = 4000,
 ) -> str:
-    """Trim and compact only oversized outlines for search_page output."""
+    """Build the search_page outline context for content-mode search results."""
     entries = parse_outline_entries(raw_outline)
     entries = strip_empty_fences(entries)
     total_entries = len(entries)
-
-    # Small outlines fit inline already — preserve the full structure instead of
-    # trimming to the match span, which can drop useful parent headings.
-    if total_entries <= max_entries and len(format_outline(entries)) <= max_chars:
-        return format_outline(entries)
-
-    # No match range — compact without trimming to a span.
-    if first_line is None or last_line is None:
-        compacted = compact_outline(entries, max_entries=max_entries, max_chars=max_chars)
-        if compacted is None:
-            return (
-                f"[Outline too large ({total_entries} entries)."
-                " Use read_outline for paginated access.]"
-            )
-        note = build_compaction_note(compacted, total_entries)
-        return note + "\n" + format_outline(compacted)
-
-    # Trim to match range
-    trimmed = trim_outline_to_range(entries, first_line, last_line)
-
-    if len(trimmed) <= max_entries and len(format_outline(trimmed)) <= max_chars:
-        return format_outline(trimmed)
-
-    compacted = compact_outline(trimmed, max_entries=max_entries, max_chars=max_chars)
-    if compacted is None:
+    selection = select_search_outline_entries(
+        entries,
+        first_line,
+        last_line,
+        max_entries=max_entries,
+        max_chars=max_chars,
+    )
+    if selection is None:
         return (
             f"[Outline too large ({total_entries} entries). Use read_outline for paginated access.]"
         )
 
-    note = build_compaction_note(compacted, total_entries, match_range=(first_line, last_line))
-    return note + "\n" + format_outline(compacted)
+    if not selection.compacted:
+        return format_outline(selection.entries)
+
+    note = build_compaction_note(
+        selection.entries,
+        total_entries,
+        match_range=(
+            (first_line, last_line) if first_line is not None and last_line is not None else None
+        ),
+    )
+    return note + "\n" + format_outline(selection.entries)

--- a/tests/integration/test_search_page.py
+++ b/tests/integration/test_search_page.py
@@ -26,6 +26,10 @@ if TYPE_CHECKING:
     from procontext.state import AppState
 
 
+def _join_lines(lines: list[str]) -> str:
+    return "\n".join(lines)
+
+
 class TestSearchPageHandler:
     """Full handler pipeline tests for search_page."""
 
@@ -281,7 +285,7 @@ class TestSearchPageHandler:
         result = await search_page_handle(url, "-------------", app_state)
 
         assert result["matches"].startswith("4:-------------")
-        assert result["outline"] == ""
+        assert result["outline"] == "3:## Match Section"
 
     @respx.mock
     async def test_search_large_outline_no_matches_compacts(self, app_state: AppState) -> None:
@@ -323,6 +327,124 @@ class TestSearchPageHandler:
 
         assert result["matches"] != ""
         assert result["outline"] is not None
+
+    @respx.mock
+    async def test_search_page_uses_tighter_char_budget_than_read_page(
+        self, app_state: AppState
+    ) -> None:
+        """read_page and search_page use different outline char budgets by default."""
+        url = "https://python.langchain.com/docs/concepts/outline-budget.md"
+        lines = ["# Top", ""]
+        for index in range(40):
+            lines.append(f"### Section {index} {'x' * 40}")
+            lines.append(f"Body content for section {index}.")
+            lines.append("")
+        page = "\n".join(lines)
+        respx.get(url).mock(return_value=httpx.Response(200, text=page))
+
+        read_result = await read_page_handle(url, 1, 500, app_state)
+        search_result = await search_page_handle(url, "xyzzy_nonexistent", app_state)
+
+        assert "[Compacted:" not in read_result["outline"]
+        assert "### Section 0" in read_result["outline"]
+        assert search_result["matches"] == ""
+        assert "[Compacted:" in search_result["outline"]
+
+    @respx.mock
+    async def test_search_rollup_includes_preceding_h2_context(self, app_state: AppState) -> None:
+        url = "https://python.langchain.com/docs/concepts/rollup-h2.md"
+        lines = ["# Top", "", "## Target Section", "", "needle body"]
+        for index in range(60):
+            lines.extend(["", f"### Detail {index}", f"Detail body {index}."])
+        respx.get(url).mock(return_value=httpx.Response(200, text=_join_lines(lines)))
+
+        result = await search_page_handle(url, "needle body", app_state)
+
+        assert result["matches"].startswith("5:needle body")
+        assert result["outline"] == "3:## Target Section"
+
+    @respx.mock
+    async def test_search_rollup_falls_back_to_h1_when_no_h2_exists(
+        self, app_state: AppState
+    ) -> None:
+        url = "https://python.langchain.com/docs/concepts/rollup-h1.md"
+        lines = ["# Top", "", "### Local Section", "", "needle body"]
+        for index in range(60):
+            lines.extend(["", f"### Detail {index}", f"Detail body {index}."])
+        respx.get(url).mock(return_value=httpx.Response(200, text=_join_lines(lines)))
+
+        result = await search_page_handle(url, "needle body", app_state)
+
+        assert result["matches"].startswith("5:needle body")
+        assert result["outline"] == "1:# Top\n3:### Local Section"
+
+    @respx.mock
+    async def test_search_rollup_uses_local_context_when_h1_h2_missing(
+        self, app_state: AppState
+    ) -> None:
+        url = "https://python.langchain.com/docs/concepts/rollup-local.md"
+        lines = ["### Local Section", "", "#### Leaf", "", "needle body"]
+        for index in range(60):
+            lines.extend(["", f"### Detail {index}", f"Detail body {index}."])
+        respx.get(url).mock(return_value=httpx.Response(200, text=_join_lines(lines)))
+
+        result = await search_page_handle(url, "needle body", app_state)
+
+        assert result["matches"].startswith("5:needle body")
+        assert result["outline"] == "1:### Local Section\n3:#### Leaf"
+
+    @respx.mock
+    async def test_search_rollup_does_not_reintroduce_h6_after_h6_reduction(
+        self, app_state: AppState
+    ) -> None:
+        url = "https://python.langchain.com/docs/concepts/rollup-h6-stage.md"
+        lines = ["# Top", "", "## Target"]
+        for index in range(20):
+            lines.extend([f"###### Leaf {index} {'x' * 60}", f"needle {index}", ""])
+        respx.get(url).mock(return_value=httpx.Response(200, text=_join_lines(lines)))
+
+        result = await search_page_handle(url, "needle", app_state)
+
+        assert result["matches"] != ""
+        assert result["outline"] is not None
+        assert "## Target" in result["outline"]
+        assert "######" not in result["outline"]
+
+    @respx.mock
+    async def test_search_rollup_does_not_reintroduce_h5_after_h5_reduction(
+        self, app_state: AppState
+    ) -> None:
+        url = "https://python.langchain.com/docs/concepts/rollup-h5-stage.md"
+        lines = ["# Top", "", "## Target"]
+        for index in range(20):
+            lines.extend([f"##### Leaf {index} {'x' * 60}", f"needle {index}", ""])
+        respx.get(url).mock(return_value=httpx.Response(200, text=_join_lines(lines)))
+
+        result = await search_page_handle(url, "needle", app_state)
+
+        assert result["matches"] != ""
+        assert result["outline"] is not None
+        assert "## Target" in result["outline"]
+        assert "#####" not in result["outline"]
+
+    @respx.mock
+    async def test_search_rollup_does_not_reintroduce_fenced_headings_after_reduction(
+        self, app_state: AppState
+    ) -> None:
+        url = "https://python.langchain.com/docs/concepts/rollup-fenced-stage.md"
+        lines = ["# Top", "", "## Target", "", "```md"]
+        for index in range(20):
+            lines.extend([f"### Fence Heading {index} {'x' * 60}", f"needle {index}", ""])
+        lines.append("```")
+        respx.get(url).mock(return_value=httpx.Response(200, text=_join_lines(lines)))
+
+        result = await search_page_handle(url, "needle", app_state)
+
+        assert result["matches"] != ""
+        assert result["outline"] is not None
+        assert "## Target" in result["outline"]
+        assert "```" not in result["outline"]
+        assert "Fence Heading" not in result["outline"]
 
     @respx.mock
     async def test_outline_search_pagination_has_more_with_later_match(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -88,7 +88,8 @@ class TestConfigValidation:
             (ResolverSettings, "fuzzy_score_cutoff", 101),
             (ResolverSettings, "fuzzy_max_results", 0),
             (OutlineSettings, "max_entries", 0),
-            (OutlineSettings, "max_chars", 0),
+            (OutlineSettings, "read_page_max_chars", 0),
+            (OutlineSettings, "search_page_max_chars", 0),
         ],
     )
     def test_invalid_numeric_bounds_raise_validation_error(
@@ -103,7 +104,7 @@ class TestConfigValidation:
         cache = CacheSettings(ttl_hours=1, cleanup_interval_hours=1)
         fetcher = FetcherSettings(connect_timeout_seconds=0.1, request_timeout_seconds=0.1)
         resolver = ResolverSettings(fuzzy_score_cutoff=0, fuzzy_max_results=1)
-        outline = OutlineSettings(max_entries=1, max_chars=1)
+        outline = OutlineSettings(max_entries=1, read_page_max_chars=1, search_page_max_chars=1)
 
         assert server.port == 1
         assert registry.poll_interval_hours == 1
@@ -114,7 +115,15 @@ class TestConfigValidation:
         assert resolver.fuzzy_score_cutoff == 0
         assert resolver.fuzzy_max_results == 1
         assert outline.max_entries == 1
-        assert outline.max_chars == 1
+        assert outline.read_page_max_chars == 1
+        assert outline.search_page_max_chars == 1
+
+    def test_legacy_outline_max_chars_alias_sets_both_limits(self) -> None:
+        outline = OutlineSettings(max_entries=1, max_chars=1234)  # type: ignore[call-arg]
+
+        assert outline.max_entries == 1
+        assert outline.read_page_max_chars == 1234
+        assert outline.search_page_max_chars == 1234
 
     def test_empty_auth_key_with_auth_enabled(self) -> None:
         """auth_key='' with auth_enabled=True is accepted by pydantic.

--- a/tests/unit/test_search_outline_context.py
+++ b/tests/unit/test_search_outline_context.py
@@ -1,0 +1,172 @@
+"""Unit tests for search-page outline rollup and stage-aware selection."""
+
+from __future__ import annotations
+
+from procontext.outline import OutlineEntry, apply_outline_reduction_stage, parse_outline_entries
+from procontext.parser import parse_outline
+from procontext.search_outline_context import (
+    build_ancestor_rollup,
+    build_match_range_with_rollup,
+    merge_outline_entries,
+    select_search_outline_entries,
+)
+
+
+def _entries(raw_outline: str) -> list[OutlineEntry]:
+    return parse_outline_entries(raw_outline)
+
+
+class TestBuildAncestorRollup:
+    def test_returns_h2_h3_h4_chain(self) -> None:
+        entries = _entries("1:# Top\n5:## Auth\n10:### OAuth\n15:#### PKCE")
+
+        result = build_ancestor_rollup(entries, 20)
+
+        assert [entry.text for entry in result] == ["## Auth", "### OAuth", "#### PKCE"]
+
+    def test_falls_back_to_h1_when_no_h2_exists(self) -> None:
+        entries = _entries("1:# Top\n10:### Local\n15:#### Leaf")
+
+        result = build_ancestor_rollup(entries, 20)
+
+        assert [entry.text for entry in result] == ["# Top", "### Local", "#### Leaf"]
+
+    def test_returns_available_local_chain_when_h1_and_h2_missing(self) -> None:
+        entries = _entries("10:### Local\n15:#### Leaf")
+
+        result = build_ancestor_rollup(entries, 20)
+
+        assert [entry.text for entry in result] == ["### Local", "#### Leaf"]
+
+    def test_same_depth_sibling_replaces_previous_heading(self) -> None:
+        entries = _entries("1:# Top\n5:## Old\n10:### Old Child\n15:## New\n20:### New Child")
+
+        result = build_ancestor_rollup(entries, 25)
+
+        assert [entry.text for entry in result] == ["## New", "### New Child"]
+
+    def test_shallower_heading_drops_deeper_ancestors(self) -> None:
+        entries = _entries("1:# Top\n5:## A\n10:### Child A\n15:## B\n20:#### Deep B")
+
+        result = build_ancestor_rollup(entries, 25)
+
+        assert [entry.text for entry in result] == ["## B", "#### Deep B"]
+
+    def test_no_preceding_headings_returns_empty(self) -> None:
+        entries = _entries("10:## Section\n20:### Match")
+
+        assert build_ancestor_rollup(entries, 10) == []
+
+    def test_setext_headings_participate_like_atx(self) -> None:
+        entries = parse_outline_entries(parse_outline("Top\n===\n\nSection\n-------\n\n### Deep"))
+
+        result = build_ancestor_rollup(entries, 8)
+
+        assert [entry.text for entry in result] == ["## Section", "### Deep"]
+
+    def test_h6_removed_stage_does_not_reintroduce_h6(self) -> None:
+        entries = _entries("1:# Top\n5:## Section\n10:###### Leaf")
+        staged = apply_outline_reduction_stage(entries, "drop_h6")
+
+        result = build_ancestor_rollup(staged, 20)
+
+        assert [entry.text for entry in result] == ["## Section"]
+        assert all(entry.depth != 6 for entry in result)
+
+    def test_h5_removed_stage_does_not_reintroduce_h5(self) -> None:
+        entries = _entries("1:# Top\n5:## Section\n10:##### Leaf")
+        staged = apply_outline_reduction_stage(entries, "drop_h5")
+
+        result = build_ancestor_rollup(staged, 20)
+
+        assert [entry.text for entry in result] == ["## Section"]
+        assert all(entry.depth != 5 for entry in result)
+
+    def test_h4_removed_stage_falls_back_to_h3(self) -> None:
+        entries = _entries("1:# Top\n5:## Section\n10:### Child\n15:#### Leaf")
+        staged = apply_outline_reduction_stage(entries, "drop_h4")
+
+        result = build_ancestor_rollup(staged, 20)
+
+        assert [entry.text for entry in result] == ["## Section", "### Child"]
+
+    def test_h3_removed_stage_falls_back_to_h2(self) -> None:
+        entries = _entries("1:# Top\n5:## Section\n10:### Child")
+        staged = apply_outline_reduction_stage(entries, "drop_h3")
+
+        result = build_ancestor_rollup(staged, 20)
+
+        assert [entry.text for entry in result] == ["## Section"]
+
+
+class TestBuildMatchRangeWithRollup:
+    def test_match_on_heading_line_does_not_duplicate_heading(self) -> None:
+        entries = _entries("1:# Top\n5:## Section\n10:### Match")
+
+        result = build_match_range_with_rollup(entries, 10, 10)
+
+        assert [entry.line_number for entry in result] == [5, 10]
+        assert [entry.text for entry in result] == ["## Section", "### Match"]
+
+    def test_empty_trimmed_range_returns_ancestor_chain_only(self) -> None:
+        entries = _entries("1:# Top\n3:## Match Section")
+
+        result = build_match_range_with_rollup(entries, 4, 4)
+
+        assert [entry.text for entry in result] == ["## Match Section"]
+
+    def test_merge_preserves_order_and_deduplicates_by_line_number(self) -> None:
+        ancestors = _entries("5:## Section\n10:### Child")
+        trimmed = _entries("10:### Child\n15:#### Match")
+
+        result = merge_outline_entries(ancestors, trimmed)
+
+        assert [entry.line_number for entry in result] == [5, 10, 15]
+
+
+class TestSelectSearchOutlineEntries:
+    def test_small_outline_returns_full_entries_without_compaction(self) -> None:
+        entries = _entries("1:# Top\n5:## Section\n10:### Match")
+
+        result = select_search_outline_entries(
+            entries,
+            first_line=10,
+            last_line=10,
+            max_entries=50,
+            max_chars=1000,
+        )
+
+        assert result is not None
+        assert result.compacted is False
+        assert result.entries == entries
+
+    def test_no_match_uses_normal_compaction(self) -> None:
+        entries = _entries("\n".join([f"10{i}:## Section {i}" for i in range(1, 56)]))
+
+        result = select_search_outline_entries(
+            entries,
+            first_line=None,
+            last_line=None,
+            max_entries=50,
+            max_chars=1000,
+        )
+
+        assert result is None
+
+    def test_stage_aware_selection_drops_h6_when_needed(self) -> None:
+        h2 = ["1:# Top", "5:## Target"]
+        h6 = [f"{10 + i * 5}:###### Leaf {i} {'x' * 60}" for i in range(20)]
+        entries = _entries("\n".join(h2 + h6))
+
+        result = select_search_outline_entries(
+            entries,
+            first_line=11,
+            last_line=105,
+            max_entries=50,
+            max_chars=1000,
+        )
+
+        assert result is not None
+        assert result.compacted is True
+        assert [entry.text for entry in result.entries] == ["## Target"]
+        assert all(entry.depth != 6 for entry in result.entries)


### PR DESCRIPTION
## Summary
- split read_page and search_page outline char budgets with a tighter default for search_page
- add stage-aware search outline rollup so oversized search results include preceding heading context without reintroducing removed depths
- expand unit and integration coverage for outline reduction, rollup edge cases, and search-page behavior

## Verification
- uv run ruff format src tests
- uv run ruff check src tests
- uv run pyright src
- uv run pytest -q